### PR TITLE
ROC-3671: Add isBooleanTrue validator

### DIFF
--- a/src/main/isBooleanTrue.ts
+++ b/src/main/isBooleanTrue.ts
@@ -1,0 +1,31 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments
+} from 'class-validator'
+
+@ValidatorConstraint()
+export class IsBooleanTrueConstraint implements ValidatorConstraintInterface {
+
+  validate (value: any, args?: ValidationArguments): boolean {
+    return typeof value === 'boolean' && (value === true)
+  }
+
+}
+
+/**
+ * Validator validates only boolean true values, everything else is considered invalid.
+ */
+export function IsBooleanTrue (validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsBooleanTrueConstraint
+    })
+  }
+}

--- a/src/test/isBooleanConstraint.ts
+++ b/src/test/isBooleanConstraint.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai'
+import { IsBooleanTrueConstraint, IsBooleanTrue } from '../main/isBooleanTrue'
+import { validateSync } from 'class-validator'
+
+class BooleanTrueTest {
+  @IsBooleanTrue()
+  boolValue?: boolean
+
+  constructor (boolValue?: boolean) {
+    this.boolValue = boolValue
+  }
+}
+
+describe('IsBooleanConstraint', () => {
+  const constraint: IsBooleanTrueConstraint = new IsBooleanTrueConstraint()
+
+  describe('validate', () => {
+
+    describe('should return true when ', () => {
+      it('given a valid case', () => {
+        expect(constraint.validate(true)).to.equal(true)
+      })
+    })
+
+    describe('should return false when ', () => {
+      it('given an invalid case', () => {
+        expect(constraint.validate(false)).to.equal(false)
+      })
+      it('given null', () => {
+        expect(constraint.validate(null)).to.equal(false)
+      })
+      it('given undefined', () => {
+        expect(constraint.validate(undefined)).to.equal(false)
+      })
+    })
+  })
+})
+
+describe('IsBooleanTrue', () => {
+
+  describe('validate', () => {
+
+    describe('should return true when ', () => {
+      it('given a valid case', () => {
+        expect(validateSync(new BooleanTrueTest(true))).to.length(0)
+      })
+    })
+
+    describe('should return false when ', () => {
+      it('given an invalid case', () => {
+        expect(validateSync(new BooleanTrueTest(false))).to.length(1)
+      })
+      it('given undefined', () => {
+        expect(validateSync(new BooleanTrueTest(undefined))).to.length(1)
+      })
+    })
+  })
+})

--- a/src/test/isBooleanTrue.spec.ts
+++ b/src/test/isBooleanTrue.spec.ts
@@ -4,14 +4,14 @@ import { validateSync } from 'class-validator'
 
 class BooleanTrueTest {
   @IsBooleanTrue()
-  boolValue?: boolean
+  boolValue?: any
 
-  constructor (boolValue?: boolean) {
+  constructor (boolValue?: any) {
     this.boolValue = boolValue
   }
 }
 
-describe('IsBooleanConstraint', () => {
+describe('IsBooleanTrue', () => {
   const constraint: IsBooleanTrueConstraint = new IsBooleanTrueConstraint()
 
   describe('validate', () => {
@@ -49,6 +49,9 @@ describe('IsBooleanTrue', () => {
     describe('should return false when ', () => {
       it('given an invalid case', () => {
         expect(validateSync(new BooleanTrueTest(false))).to.length(1)
+      })
+      it('given null', () => {
+        expect(validateSync(new BooleanTrueTest(null))).to.length(1)
       })
       it('given undefined', () => {
         expect(validateSync(new BooleanTrueTest(undefined))).to.length(1)

--- a/src/test/isNotBlank.spec.ts
+++ b/src/test/isNotBlank.spec.ts
@@ -1,36 +1,45 @@
 import { expect } from 'chai'
-import { IsNotBlankConstraint } from '../main/isNotBlank'
+import { IsNotBlank } from '../main/isNotBlank'
+import { validateSync } from 'class-validator'
+
+class NotBlankTest {
+  @IsNotBlank()
+  value?: any
+
+  constructor (value?: any) {
+    this.value = value
+  }
+}
 
 describe('IsNotBlank', () => {
-  const constraint: IsNotBlankConstraint = new IsNotBlankConstraint()
 
   describe('validate', () => {
 
     describe('should return true when ', () => {
 
       it('given an undefined value', () => {
-        expect(constraint.validate(undefined)).to.be.equal(true)
+        expect(validateSync(new NotBlankTest(undefined))).to.be.length(0)
       })
 
       it('given ab non blank value', () => {
-        expect(constraint.validate('something')).to.be.equal(true)
+        expect(validateSync(new NotBlankTest('Something'))).to.be.length(0)
       })
     })
 
     describe('should return false when ', () => {
 
       it('given an non string value', () => {
-        expect(constraint.validate(true)).to.be.equal(false)
-        expect(constraint.validate(999)).to.be.equal(false)
-        expect(constraint.validate({})).to.be.equal(false)
+        expect(validateSync(new NotBlankTest(true))).to.be.length(1)
+        expect(validateSync(new NotBlankTest(999))).to.be.length(1)
+        expect(validateSync(new NotBlankTest({}))).to.be.length(1)
       })
 
       it('given an empty value', () => {
-        expect(constraint.validate('')).to.be.equal(false)
+        expect(validateSync(new NotBlankTest(''))).to.be.length(1)
       })
 
       it('given an blank value', () => {
-        expect(constraint.validate(' ')).to.be.equal(false)
+        expect(validateSync(new NotBlankTest(' '))).to.be.length(1)
       })
 
     })

--- a/src/test/isValidPostcode.spec.ts
+++ b/src/test/isValidPostcode.spec.ts
@@ -1,61 +1,70 @@
 import { expect } from 'chai'
-import { IsValidPostcodeConstraint } from '../main/isValidPostcode'
+import { IsValidPostcode } from '../main/isValidPostcode'
+import { validateSync } from 'class-validator'
+
+class ValidPostcodeTest {
+  @IsValidPostcode()
+  value?: any
+
+  constructor (value?: any) {
+    this.value = value
+  }
+}
 
 describe('IsValidPostcodeConstraint', () => {
-  const constraint: IsValidPostcodeConstraint = new IsValidPostcodeConstraint()
 
   describe('validate', () => {
 
     describe('should return true when ', () => {
 
       it('given an undefined value', () => {
-        expect(constraint.validate(undefined)).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest(undefined))).to.be.length(0)
       })
 
       it('given an null value', () => {
-        expect(constraint.validate(null)).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest(null))).to.be.length(0)
       })
 
       it('given a valid postcode in lowercase', () => {
-        expect(constraint.validate('sw1h9aj')).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest('sw1h9aj'))).to.be.length(0)
       })
 
       it('given a valid postcode in uppercase', () => {
-        expect(constraint.validate('SW1H9AJ')).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest('SW1H9AJ'))).to.length(0)
       })
 
       it('given a valid postcode in mixed case', () => {
-        expect(constraint.validate('Sw1H9aJ')).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest('Sw1H9aJ'))).to.length(0)
       })
 
       it('given a valid postcode in uppercase with space', () => {
-        expect(constraint.validate('SW1H 9AJ')).to.equal(true)
+        expect(validateSync(new ValidPostcodeTest('SW1H 9AJ'))).to.be.length(0)
       })
 
       describe('should return true for valid formats ', () => {
 
         it('given a valid postcode of format AN NAA', () => {
-          expect(constraint.validate('M1 1AA')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('M1 1AA'))).to.be.length(0)
         })
 
         it('given a valid postcode of format ANN NAA', () => {
-          expect(constraint.validate('M60 1NW')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('M60 1NW'))).to.be.length(0)
         })
 
         it('given a valid postcode of format AAN NAA', () => {
-          expect(constraint.validate('CR2 6HX')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('CR2 6HX'))).to.be.length(0)
         })
 
         it('given a valid postcode of format AANN NAA', () => {
-          expect(constraint.validate('DN55 1PT')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('DN55 1PT'))).to.be.length(0)
         })
 
         it('given a valid postcode of format ANA NAA', () => {
-          expect(constraint.validate('W1A 0AX')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('W1A 0AX'))).to.be.length(0)
         })
 
         it('given a valid postcode of format AANA NAA', () => {
-          expect(constraint.validate('EC1A 1BB')).to.equal(true)
+          expect(validateSync(new ValidPostcodeTest('EC1A 1BB'))).to.be.length(0)
         })
       })
 
@@ -63,19 +72,19 @@ describe('IsValidPostcodeConstraint', () => {
 
     describe('should return false when ', () => {
       it('given an invalid postcode', () => {
-        expect(constraint.validate('aaaaa')).to.equal(false)
+        expect(validateSync(new ValidPostcodeTest('aaaaa'))).to.be.length(1)
       })
 
       it('given a number', () => {
-        expect(constraint.validate(123)).to.equal(false)
+        expect(validateSync(new ValidPostcodeTest(123))).to.be.length(1)
       })
 
       it('given an object', () => {
-        expect(constraint.validate({})).to.equal(false)
+        expect(validateSync(new ValidPostcodeTest({}))).to.be.length(1)
       })
 
       it('given an empty value', () => {
-        expect(constraint.validate('')).to.equal(false)
+        expect(validateSync(new ValidPostcodeTest(''))).to.be.length(1)
       })
     })
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,18 @@
     ],
     "target": "es6",
     "module": "commonjs",
-    "baseUrl": "src/main",
+    "baseUrl": "src",
     "typeRoots": [
       "./node_modules/@types",
       "./types"
-    ]
+    ],
+    "paths": {
+      "validators/*":[
+        "main/*"
+      ],
+      "test/*": [
+        "test/*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Updated existing unit tests to use validator annotations, allowing for 100% code coverage on existing tests.

Added isBooleanTrue validator from cmc-citizen-frontend