### PR TITLE
Feature/roc 7170 contact name

### DIFF
--- a/src/main/isNotEmail.ts
+++ b/src/main/isNotEmail.ts
@@ -12,11 +12,7 @@ import * as validator from 'validator'
 export class IsNotEmailConstraint implements ValidatorConstraintInterface {
 
   validate (value: any, args: ValidationArguments): boolean {
-    if (value === undefined || value === null) {
-      return true
-    } else {
-      return (value.length === 0 || !validator.isEmail(value))
-    }
+    return !value || value.length === 0 || !validator.isEmail(value)
   }
 }
 

--- a/src/main/isNotEmail.ts
+++ b/src/main/isNotEmail.ts
@@ -1,0 +1,35 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments
+} from '@hmcts/class-validator'
+
+import * as validator from 'validator'
+
+@ValidatorConstraint()
+export class IsEmailConstraint implements ValidatorConstraintInterface {
+
+  validate (value: any, args: ValidationArguments): boolean {
+    return typeof value === 'string' && (value.length !== 0 && !validator.isEmail(value))
+  }
+}
+
+/**
+ * Verify not an email address.
+ *
+ * Validator validates only non empty string values, everything else is considered valid.
+ */
+export function IsEmail (validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsEmail',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsEmailConstraint
+    })
+  }
+}

--- a/src/main/isNotEmail.ts
+++ b/src/main/isNotEmail.ts
@@ -9,27 +9,25 @@ import {
 import * as validator from 'validator'
 
 @ValidatorConstraint()
-export class IsEmailConstraint implements ValidatorConstraintInterface {
+export class IsNotEmailConstraint implements ValidatorConstraintInterface {
 
   validate (value: any, args: ValidationArguments): boolean {
-    return typeof value === 'string' && (value.length !== 0 && !validator.isEmail(value))
+    return (typeof value === 'string' && value.length !== 0 && !validator.isEmail(value)) || value.length === 0
   }
 }
 
 /**
- * Verify not an email address.
- *
- * Validator validates only non empty string values, everything else is considered valid.
+ * Verify not an email address if the value is not empty.
  */
-export function IsEmail (validationOptions?: ValidationOptions) {
+export function IsNotEmail (validationOptions?: ValidationOptions) {
   return function (object: Object, propertyName: string) {
     registerDecorator({
-      name: 'IsEmail',
+      name: 'IsNotEmail',
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,
       constraints: [],
-      validator: IsEmailConstraint
+      validator: IsNotEmailConstraint
     })
   }
 }

--- a/src/main/isNotEmail.ts
+++ b/src/main/isNotEmail.ts
@@ -12,7 +12,11 @@ import * as validator from 'validator'
 export class IsNotEmailConstraint implements ValidatorConstraintInterface {
 
   validate (value: any, args: ValidationArguments): boolean {
-    return (typeof value === 'string' && value.length !== 0 && !validator.isEmail(value)) || value.length === 0
+    if (value === undefined || value === null) {
+      return true
+    } else {
+      return (value.length === 0 || !validator.isEmail(value))
+    }
   }
 }
 

--- a/src/test/isNotEmail.spec.ts
+++ b/src/test/isNotEmail.spec.ts
@@ -52,14 +52,6 @@ describe('IsNotEmail', () => {
       })
     })
 
-    it('given a number', () => {
-      expect(validateSync(new NotEmailTest(123))).to.be.empty
-    })
-
-    it('given an object', () => {
-      expect(validateSync(new NotEmailTest({}))).to.be.empty
-    })
-
     it('given null', () => {
       expect(validateSync(new NotEmailTest(null))).to.be.empty
     })

--- a/src/test/isNotEmail.spec.ts
+++ b/src/test/isNotEmail.spec.ts
@@ -31,7 +31,7 @@ const invalidContactNames = [
 
 describe('IsNotEmail', () => {
   describe('should have no validation errors when', () => {
-    context('given a valid email address', () => {
+    context('given a valid contact name', () => {
       validContactNames.forEach(name => {
         it(name, () => {
           expect(validateSync(new NotEmailTest(name)), name).to.be.empty

--- a/src/test/isNotEmail.spec.ts
+++ b/src/test/isNotEmail.spec.ts
@@ -11,13 +11,13 @@ class NotEmailTest {
   }
 }
 
-const validContactNames = [
+const invalidEmails = [
   'test',
   'first name',
   'first middle last'
 ]
 
-const invalidContactNames = [
+const validEmails = [
   'email@domain.com',
   'email@domain.COM',
   'firstname.lastname@domain.com',
@@ -32,7 +32,7 @@ const invalidContactNames = [
 describe('IsNotEmail', () => {
   describe('should have no validation errors when', () => {
     context('given a valid contact name', () => {
-      validContactNames.forEach(name => {
+      invalidEmails.forEach(name => {
         it(name, () => {
           expect(validateSync(new NotEmailTest(name)), name).to.be.empty
         })
@@ -45,7 +45,7 @@ describe('IsNotEmail', () => {
   })
   describe('should have a validation error when', () => {
     context('given an email address', () => {
-      invalidContactNames.forEach(address => {
+      validEmails.forEach(address => {
         it(address, () => {
           expect(validateSync(new NotEmailTest(address))).to.not.be.empty
         })

--- a/src/test/isNotEmail.spec.ts
+++ b/src/test/isNotEmail.spec.ts
@@ -1,0 +1,71 @@
+import { IsNotEmail } from '../main/isNotEmail'
+import { expect } from 'chai'
+import { validateSync } from '@hmcts/class-validator'
+
+class NotEmailTest {
+  @IsNotEmail()
+  value: any
+
+  constructor (value: any) {
+    this.value = value
+  }
+}
+
+const validContactNames = [
+  'test',
+  'first name',
+  'first middle last'
+]
+
+const invalidContactNames = [
+  'email@domain.com',
+  'email@domain.COM',
+  'firstname.lastname@domain.com',
+  'firstname.o\'lastname@domain.com',
+  'email@subdomain.domain.com',
+  'firstname+lastname@domain.com',
+  '1234567890@domain.com',
+  'email@domain-one.com',
+  '_______@domain.com'
+]
+
+describe('IsNotEmail', () => {
+  describe('should have no validation errors when', () => {
+    context('given a valid email address', () => {
+      validContactNames.forEach(name => {
+        it(name, () => {
+          expect(validateSync(new NotEmailTest(name)), name).to.be.empty
+        })
+      })
+    })
+
+    it('given an empty string', () => {
+      expect(validateSync(new NotEmailTest(''))).to.be.empty
+    })
+  })
+  describe('should have a validation error when', () => {
+    context('given an email address', () => {
+      invalidContactNames.forEach(address => {
+        it(address, () => {
+          expect(validateSync(new NotEmailTest(address))).to.not.be.empty
+        })
+      })
+    })
+
+    it('given a number', () => {
+      expect(validateSync(new NotEmailTest(123))).to.be.empty
+    })
+
+    it('given an object', () => {
+      expect(validateSync(new NotEmailTest({}))).to.be.empty
+    })
+
+    it('given null', () => {
+      expect(validateSync(new NotEmailTest(null))).to.be.empty
+    })
+
+    it('given undefined', () => {
+      expect(validateSync(new NotEmailTest(undefined))).to.be.empty
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,6 +1911,11 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,11 +1911,6 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-7170

### Change description ###

When creating a new claim as a company or organisation there is a field for Contact Name (Optional).
We need to validate that if the user fills this field they don't use their email address. A new validator called isNotEmail has been added to support the functionality.

This PR is a dependancy for a  cmc-citizen-frontend change. Until this is approved and merged, cannot raise the other request

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
